### PR TITLE
Fix closing ul tag in report

### DIFF
--- a/lib/report/eval.rb
+++ b/lib/report/eval.rb
@@ -34,7 +34,7 @@ module Report::Eval
 
       b[:build_details][:failed_steps]
         .map do |step|
-          build_id = 
+          build_id =
             if step[:status][:type] == "Aborted" then
               "Aborted"
             else
@@ -146,7 +146,7 @@ module Report::Eval
             ].join(" ")
             acc << "</li>"
           end
-          acc << "<ul>"
+          acc << "</ul>"
           acc << "</details>"
         end
         acc << "</td>"


### PR DESCRIPTION
Reports generated by `eval-report` had a small error where some `ul` tags weren't properly closed.